### PR TITLE
#45 Fix Host header on forwarded requests

### DIFF
--- a/src/test/groovy/com/github/mkopylec/charon/specification/ProxyingRequestSpec.groovy
+++ b/src/test/groovy/com/github/mkopylec/charon/specification/ProxyingRequestSpec.groovy
@@ -12,7 +12,7 @@ import static org.springframework.http.HttpMethod.POST
 import static org.springframework.http.HttpMethod.PUT
 import static org.springframework.http.HttpMethod.TRACE
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
-import static org.springframework.http.HttpStatus.MOVED_PERMANENTLY
+import static org.springframework.http.HttpStatus.OK
 
 abstract class ProxyingRequestSpec extends BasicSpec {
 
@@ -145,6 +145,7 @@ abstract class ProxyingRequestSpec extends BasicSpec {
 
         then:
         assertThat(response)
-                .hasStatus(MOVED_PERMANENTLY)
+                .hasStatus(OK)
+                .bodyContains("<link rel=\"canonical\" href=\"https://github.com/\"")
     }
 }


### PR DESCRIPTION
This fixes #45 

The test "`def "Should proxy HTTPS request"()`" demonstrates that this fix works -- previously TLS requests that were being forwarded to https://github.com had a `Host` header of `localhost`, and were being rejected by GitHub's server. Now the request is succeeding.