### PR TITLE
fix wrong content-length in function RequestForwarder.forwardhttpRequest()

### DIFF
--- a/src/main/java/com/github/mkopylec/charon/core/http/RequestForwarder.java
+++ b/src/main/java/com/github/mkopylec/charon/core/http/RequestForwarder.java
@@ -82,7 +82,7 @@ public class RequestForwarder {
 
         return status(response.getStatus())
                 .headers(response.getHeaders())
-                .contentLength(response.getBody().length)
+                .contentLength(response.getBody() != null ? response.getBody().length : 0)
                 .body(response.getBody());
     }
 

--- a/src/main/java/com/github/mkopylec/charon/core/http/RequestForwarder.java
+++ b/src/main/java/com/github/mkopylec/charon/core/http/RequestForwarder.java
@@ -82,6 +82,7 @@ public class RequestForwarder {
 
         return status(response.getStatus())
                 .headers(response.getHeaders())
+                .contentLength(response.getBody().length)
                 .body(response.getBody());
     }
 


### PR DESCRIPTION
RequestForwarder return wrong content-length value when rewrite  body.

my CustomReceivedResponseInterceptor is bellow.

```
@Component
public class CustomReceivedResponseInterceptor implements ReceivedResponseInterceptor {
    final Pattern urlBeforPattern = Pattern.compile("=\\s*\\\"\\/");
    static final String urlAfterPattern = "=\"../";
    final Pattern cssBeforPattern = Pattern.compile("url\\(\\/image");
    static final String cssAfterPattern = "url(../image";
    final Pattern jsWindowOpenPatternBeforPattern = Pattern.compile("=\\s*window\\.open\\(\\'\\/");
    static final String jsWindowOpenPatternAfterPattern = "=window.open('../";
    final Pattern jsLocationReplacePatternBeforPattern = Pattern.compile("location\\.replace\\(\\\"\\/");
    static final String jsLocationReplacePatternAfterPattern = "location.replace(\"../";
    final Pattern jsUrlParamCgiBeforPattern = Pattern.compile("\\\"\\/cgi-bin\\/");
    static final String jsUrlParamCgiAfterPattern = "\"../cgi-bin/";
    final Pattern jsUrlParamImgBeforPattern = Pattern.compile("\\\",\\s*\\\"\\/");
    static final String jsUrlParamImgAfterPattern = "\",\"../";
    final Pattern jsOpenGetBeforPattern = Pattern.compile("\\.open\\(\\\"GET\\\",\\s*\\\"\\/");
    static final String jsOpenGetAfterPattern = ".open(\"GET\",\"../";
    final Pattern crLfPattern = Pattern.compile("[\r\n]+");

    @Override
    public void intercept(ResponseData data) {
        // rewite fullpath to relative path  (html/Js/Css)
        if (data.getHeaders().containsKey("Content-Type")) {
            if (data.getHeaders().get("Content-Type").contains("text/html") || data.getHeaders().get("Content-Type").contains("text/javascript")
                    ) {
                    data.setBody(
                            jsUrlParamImgBeforPattern.matcher(
                                    jsUrlParamCgiBeforPattern.matcher(
                                            jsLocationReplacePatternBeforPattern.matcher(
                                                    jsOpenGetBeforPattern.matcher(
                                                            jsWindowOpenPatternBeforPattern.matcher(
                                                                    cssBeforPattern.matcher(
                                                                            urlBeforPattern.matcher(
                                                                                    data.getBodyAsString()
                                                                            ).replaceAll(urlAfterPattern)
                                                                    ).replaceAll(cssAfterPattern)
                                                            ).replaceAll(jsWindowOpenPatternAfterPattern)
                                                    ).replaceAll(jsOpenGetAfterPattern)
                                            ).replaceAll(jsLocationReplacePatternAfterPattern)
                                    ).replaceAll(jsUrlParamCgiAfterPattern)
                            ).replaceAll(jsUrlParamImgAfterPattern)
                    );
            } else if (data.getHeaders().get("Content-Type").contains("text/css")) {
                data.setBody(
                        cssBeforPattern.matcher(
                        data.getBodyAsString()).replaceAll(cssAfterPattern)
                );
            }
        }
    }
}
```

Original response headers.  rewrite off:
```
Accept-Ranges: bytes
Cache-Control	: no-cache
Connection: keep-alive
Content-Length: 30670
Content-Type: text/javascript
Status: 200
```
Original response headers.  rewrite on:
```
Accept-Ranges: bytes
Cache-Control	: no-cache
Connection: keep-alive
Content-Length: 30670  <-- 30670 is wrong value!
Content-Type: text/javascript
Status: 200
```
