### PR TITLE
Allow ReceivedResponseInterceptor to access RequestData

### DIFF
--- a/src/main/java/com/github/mkopylec/charon/core/http/RequestForwarder.java
+++ b/src/main/java/com/github/mkopylec/charon/core/http/RequestForwarder.java
@@ -76,7 +76,7 @@ public class RequestForwarder {
         traceInterceptor.onForwardStart(traceId, destination.getMappingName(), data.getMethod(), destination.getUri().toString(), data.getBody(), data.getHeaders());
         context.setAttribute(MAPPING_NAME_RETRY_ATTRIBUTE, destination.getMappingName());
         RequestEntity<byte[]> request = new RequestEntity<>(data.getBody(), data.getHeaders(), data.getMethod(), destination.getUri());
-        ResponseData response = sendRequest(traceId, request, mapping, destination.getMappingMetricsName());
+        ResponseData response = sendRequest(traceId, request, mapping, destination.getMappingMetricsName(), data);
 
         log.debug("Forwarding: {} {} -> {} {}", data.getMethod(), data.getUri(), destination.getUri(), response.getStatus().value());
 
@@ -128,7 +128,7 @@ public class RequestForwarder {
         }
     }
 
-    protected ResponseData sendRequest(String traceId, RequestEntity<byte[]> request, MappingProperties mapping, String mappingMetricsName) {
+    protected ResponseData sendRequest(String traceId, RequestEntity<byte[]> request, MappingProperties mapping, String mappingMetricsName, RequestData requestData) {
         ResponseEntity<byte[]> response;
         Context context = null;
         if (charon.getMetrics().isEnabled()) {
@@ -151,7 +151,7 @@ public class RequestForwarder {
             traceInterceptor.onForwardFailed(traceId, e);
             throw e;
         }
-        return new ResponseData(response.getStatusCode(), response.getHeaders(), response.getBody());
+        return new ResponseData(response.getStatusCode(), response.getHeaders(), response.getBody(), requestData);
     }
 
     protected void stopTimerContext(Context context) {

--- a/src/main/java/com/github/mkopylec/charon/core/http/ResponseData.java
+++ b/src/main/java/com/github/mkopylec/charon/core/http/ResponseData.java
@@ -11,12 +11,14 @@ public class ResponseData {
     protected HttpStatus status;
     protected HttpHeaders headers;
     protected byte[] body;
+    protected RequestData requestData;
 
-    public ResponseData(HttpStatus status, HttpHeaders headers, byte[] body) {
+    public ResponseData(HttpStatus status, HttpHeaders headers, byte[] body, RequestData requestData) {
         this.status = status;
         this.headers = new HttpHeaders();
         this.headers.putAll(headers);
         this.body = body;
+        this.requestData = requestData;
     }
 
     public HttpStatus getStatus() {
@@ -49,5 +51,13 @@ public class ResponseData {
 
     public void setBody(String body) {
         this.body = convertStringToBody(body);
+    }
+
+    public RequestData getRequestData() {
+        return requestData;
+    }
+
+    public void setRequestData(RequestData requestData) {
+        this.requestData = requestData;
     }
 }

--- a/src/test/groovy/com/github/mkopylec/charon/assertions/Assertions.groovy
+++ b/src/test/groovy/com/github/mkopylec/charon/assertions/Assertions.groovy
@@ -1,6 +1,7 @@
 package com.github.mkopylec.charon.assertions
 
 import com.github.mkopylec.charon.application.GraphiteServerMock
+import com.github.mkopylec.charon.application.TestForwardedRequestInterceptor
 import com.github.mkopylec.charon.application.TestTraceInterceptor
 import com.github.tomakehurst.wiremock.junit.WireMockRule
 import org.springframework.http.ResponseEntity
@@ -21,5 +22,9 @@ class Assertions {
 
     static TraceAssert assertThat(TestTraceInterceptor traceInterceptor) {
         return new TraceAssert(traceInterceptor)
+    }
+
+    static InterceptorAssert assertThat(TestForwardedRequestInterceptor interceptor) {
+        return new InterceptorAssert(interceptor);
     }
 }

--- a/src/test/groovy/com/github/mkopylec/charon/assertions/InterceptorAssert.groovy
+++ b/src/test/groovy/com/github/mkopylec/charon/assertions/InterceptorAssert.groovy
@@ -1,0 +1,58 @@
+package com.github.mkopylec.charon.assertions
+
+import com.github.mkopylec.charon.application.TestForwardedRequestInterceptor
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+
+
+class InterceptorAssert {
+
+    private TestForwardedRequestInterceptor actual
+
+    protected InterceptorAssert(TestForwardedRequestInterceptor actual) {
+        assert actual != null
+        this.actual = actual
+    }
+
+    InterceptorAssert hasInterceptedRequest() {
+        assert actual.getInterceptedRequest() != null
+        return this
+    }
+
+    InterceptorAssert hasInterceptedResponse() {
+        assert actual.getInterceptedResponse() != null
+        return this
+    }
+
+    InterceptorAssert withRequestInResponse() {
+        assert actual.getInterceptedResponse().requestData == actual.getInterceptedRequest()
+        return this
+    }
+
+    InterceptorAssert withRequestMethod(HttpMethod method) {
+        assert actual.getInterceptedRequest().method == method
+        return this
+    }
+
+    InterceptorAssert withRequestUri(String uri) {
+        assert actual.getInterceptedRequest().uri == uri;
+        return this
+    }
+
+    InterceptorAssert withRequestHeader(String name, String value) {
+        assert actual.getInterceptedRequest().headers != null &&
+                actual.getInterceptedRequest().headers.get(name) != null &&
+                actual.getInterceptedRequest().headers.get(name).contains(value)
+        return this
+    }
+
+    InterceptorAssert withResponseStatus(HttpStatus status) {
+        assert actual.getInterceptedResponse().status == status
+        return this
+    }
+
+    InterceptorAssert withResponseBody(String body) {
+        assert Arrays.equals(actual.getInterceptedResponse().body, body.bytes)
+        return this
+    }
+}

--- a/src/test/groovy/com/github/mkopylec/charon/specification/ProxyingInterceptingSpec.groovy
+++ b/src/test/groovy/com/github/mkopylec/charon/specification/ProxyingInterceptingSpec.groovy
@@ -51,7 +51,16 @@ class ProxyingInterceptingSpec extends BasicSpec {
         assertThat(response)
                 .hasStatus(CREATED)
                 .hasBody(INTERCEPTED_BODY)
+    }
 
+    def "Should receive correct request and response data"() {
+        given:
+        stubDestinationResponse OK
+
+        when:
+        def response = sendRequest GET, '/uri/1/sync'
+
+        then:
         assertThat(interceptor)
                 .hasInterceptedRequest()
                 .hasInterceptedResponse()

--- a/src/test/groovy/com/github/mkopylec/charon/specification/ProxyingInterceptingSpec.groovy
+++ b/src/test/groovy/com/github/mkopylec/charon/specification/ProxyingInterceptingSpec.groovy
@@ -1,6 +1,8 @@
 package com.github.mkopylec.charon.specification
 
 import com.github.mkopylec.charon.BasicSpec
+import com.github.mkopylec.charon.application.TestForwardedRequestInterceptor
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.TestPropertySource
 import spock.lang.Unroll
 
@@ -15,6 +17,9 @@ import static org.springframework.http.HttpStatus.OK
 
 @TestPropertySource(properties = ['test.interceptors-enabled: true'])
 class ProxyingInterceptingSpec extends BasicSpec {
+
+    @Autowired
+    private TestForwardedRequestInterceptor interceptor
 
     @Unroll
     def "Should change forwarded request while proxying HTTP request when URI is #requestUri"() {
@@ -46,6 +51,17 @@ class ProxyingInterceptingSpec extends BasicSpec {
         assertThat(response)
                 .hasStatus(CREATED)
                 .hasBody(INTERCEPTED_BODY)
+
+        assertThat(interceptor)
+                .hasInterceptedRequest()
+                .hasInterceptedResponse()
+                .withRequestInResponse()
+                .withRequestMethod(DELETE)
+                .withRequestUri('/uri/1/sync')
+                .withRequestHeader('Authorization', INTERCEPTED_AUTHORIZATION)
+                .withRequestHeader('X-Forwarded-For', '127.0.0.1')
+                .withResponseStatus(CREATED)
+                .withResponseBody(INTERCEPTED_BODY)
     }
 
     def "Should not change HTTP response while proxying HTTP request when asynchronous mode is enabled"() {

--- a/src/test/groovy/com/github/mkopylec/charon/specification/RequestDataSpec.groovy
+++ b/src/test/groovy/com/github/mkopylec/charon/specification/RequestDataSpec.groovy
@@ -1,0 +1,47 @@
+package com.github.mkopylec.charon.specification
+
+import com.github.mkopylec.charon.BasicSpec
+import com.github.mkopylec.charon.core.http.RequestData
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+
+class RequestDataSpec extends BasicSpec {
+
+    def "Should have a functional constructor"() {
+        given:
+        def method = HttpMethod.GET
+        def uri = ""
+        def headers = new HttpHeaders()
+        def body = "".bytes
+
+        when:
+        def requestData = new RequestData(method, uri, headers, body)
+
+        then:
+        requestData.getMethod() == method
+        requestData.getUri() == uri
+        requestData.getHeaders() == headers
+        requestData.getBody() == body
+    }
+
+    def "Should have functional setters"() {
+        given:
+        def method = HttpMethod.GET
+        def uri = ""
+        def headers = new HttpHeaders()
+        def body = "".bytes
+        def requestData = new RequestData(null, null, null, null)
+
+        when:
+        requestData.setMethod(method)
+        requestData.setUri(uri)
+        requestData.setHeaders(headers)
+        requestData.setBody(body)
+
+        then:
+        requestData.getMethod() == method
+        requestData.getUri() == uri
+        requestData.getHeaders() == headers
+        requestData.getBody() == body
+    }
+}

--- a/src/test/groovy/com/github/mkopylec/charon/specification/ResponseDataSpec.groovy
+++ b/src/test/groovy/com/github/mkopylec/charon/specification/ResponseDataSpec.groovy
@@ -1,0 +1,48 @@
+package com.github.mkopylec.charon.specification
+
+import com.github.mkopylec.charon.BasicSpec
+import com.github.mkopylec.charon.core.http.RequestData
+import com.github.mkopylec.charon.core.http.ResponseData
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+
+class ResponseDataSpec extends BasicSpec {
+
+    def "Should have a functional constructor"() {
+        given:
+        def status = HttpStatus.OK
+        def headers = new HttpHeaders()
+        def body = "".bytes
+        def requestData = new RequestData(null, null, null, null)
+
+        when:
+        def responseData = new ResponseData(status, headers, body, requestData)
+
+        then:
+        responseData.getStatus() == status
+        responseData.getHeaders() == headers
+        responseData.getBody() == body
+        responseData.getRequestData() == requestData
+    }
+
+    def "Should have functional setters"() {
+        given:
+        def status = HttpStatus.OK
+        def headers = new HttpHeaders()
+        def body = "".bytes
+        def requestData = new RequestData(null, null, null, null)
+        def responseData = new ResponseData(null, new HttpHeaders(), null, null)
+
+        when:
+        responseData.setStatus(status)
+        responseData.setHeaders(headers)
+        responseData.setBody(body)
+        responseData.setRequestData(requestData)
+
+        then:
+        responseData.getStatus() == status
+        responseData.getHeaders() == headers
+        responseData.getBody() == body
+        responseData.getRequestData() == requestData
+    }
+}

--- a/src/test/java/com/github/mkopylec/charon/application/TestForwardedRequestInterceptor.java
+++ b/src/test/java/com/github/mkopylec/charon/application/TestForwardedRequestInterceptor.java
@@ -19,15 +19,28 @@ public class TestForwardedRequestInterceptor implements ForwardedRequestIntercep
     public static final String INTERCEPTED_AUTHORIZATION = "intercepted-authorization";
     public static final String INTERCEPTED_BODY = "intercepted-body";
 
+    private RequestData interceptedRequest = null;
+    private ResponseData interceptedResponse = null;
+
     @Override
     public void intercept(RequestData data) {
+        interceptedRequest = data;
         data.setMethod(DELETE);
         data.getHeaders().set(AUTHORIZATION, INTERCEPTED_AUTHORIZATION);
     }
 
     @Override
     public void intercept(ResponseData data) {
+        interceptedResponse = data;
         data.setStatus(CREATED);
         data.setBody(INTERCEPTED_BODY);
+    }
+
+    public RequestData getInterceptedRequest() {
+        return interceptedRequest;
+    }
+
+    public ResponseData getInterceptedResponse() {
+        return interceptedResponse;
     }
 }


### PR DESCRIPTION
Some use-cases require `ReceivedResponseInterceptor` to have access to `RequestData`.
One example is properly handling CORS preflight requests from within Charon, which requires access to the request's method and headers.
This PR adds a reference to `RequestData` in `ResponseData`, allowing `ReceivedResponseInterceptor` to access it.