### PR TITLE
Allow forwarding / rewriting of URIs with percentage encoded characters | Fixed https://github.com/mkopylec/charon-spring-boot-starter/issues/115

### DIFF
--- a/charon-common/src/main/java/com/github/mkopylec/charon/forwarding/interceptors/rewrite/CommonRegexRequestPathRewriter.java
+++ b/charon-common/src/main/java/com/github/mkopylec/charon/forwarding/interceptors/rewrite/CommonRegexRequestPathRewriter.java
@@ -8,6 +8,8 @@ import java.util.regex.Pattern;
 import com.github.mkopylec.charon.configuration.Valid;
 import com.github.mkopylec.charon.forwarding.interceptors.RequestForwardingInterceptorType;
 import org.slf4j.Logger;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import static com.github.mkopylec.charon.forwarding.RequestForwardingException.requestForwardingError;
 import static com.github.mkopylec.charon.forwarding.RequestForwardingException.requestForwardingErrorIf;
@@ -46,8 +48,10 @@ abstract class CommonRegexRequestPathRewriter implements Valid {
         } catch (IllegalArgumentException e) {
             throw requestForwardingError("Path rewriter regex pattern " + incomingRequestPathRegex + " does not contain groups required to fill request path template " + outgoingRequestPathTemplate, e);
         }
+        
+        UriComponents rewrittenPathEncodedURI = UriComponentsBuilder.fromPath(rewrittenPath).build().encode();
         URI rewrittenUri = fromUri(uri)
-                .replacePath(rewrittenPath)
+                .replacePath(rewrittenPathEncodedURI.getPath())
                 .build(true)
                 .toUri();
         rewrittenUriSetter.accept(rewrittenUri);


### PR DESCRIPTION
Fixed https://github.com/mkopylec/charon-spring-boot-starter/issues/115 according to https://www.baeldung.com/spring-uricomponentsbuilder
---
 - Allow forwarding / rewriting of URIs with percentage encoded characters https://tools.ietf.org/html/rfc3986#section-2.1
 - e.g. %20
