### PR TITLE
Include port in X-Forwarded-Host header if not default

### DIFF
--- a/charon-common/src/main/java/com/github/mkopylec/charon/forwarding/interceptors/rewrite/CommonRequestProxyHeadersRewriter.java
+++ b/charon-common/src/main/java/com/github/mkopylec/charon/forwarding/interceptors/rewrite/CommonRequestProxyHeadersRewriter.java
@@ -38,7 +38,13 @@ abstract class CommonRequestProxyHeadersRewriter implements Valid {
         forwardedFor.add(uri.getAuthority());
         rewrittenHeaders.put(X_FORWARDED_FOR, forwardedFor);
         rewrittenHeaders.set(X_FORWARDED_PROTO, uri.getScheme());
-        rewrittenHeaders.set(X_FORWARDED_HOST, uri.getHost());
+
+        if (uri.getPort() == -1) {
+            rewrittenHeaders.set(X_FORWARDED_HOST, uri.getHost());
+        } else {
+            rewrittenHeaders.set(X_FORWARDED_HOST, uri.getHost() + ":" + uri.getPort());
+        }
+
         rewrittenHeaders.set(X_FORWARDED_PORT, resolvePort(uri));
         headersSetter.accept(rewrittenHeaders);
         log.debug("Request headers rewritten from {} to {}", headers, rewrittenHeaders);

--- a/charon-test/src/main/groovy/com/github/mkopylec/charon/test/specification/RequestProxyHeadersRewritingBasicSpec.groovy
+++ b/charon-test/src/main/groovy/com/github/mkopylec/charon/test/specification/RequestProxyHeadersRewritingBasicSpec.groovy
@@ -28,7 +28,7 @@ abstract class RequestProxyHeadersRewritingBasicSpec extends BasicSpec {
         ['Host': 'example.com']                                                   | ['X-Forwarded-For': 'example.com']
         ['Host': 'example.com']                                                   | ['X-Forwarded-Proto': 'http']
         ['Host': 'example.com']                                                   | ['X-Forwarded-Host': 'example.com']
-        ['Host': 'example.com:666']                                               | ['X-Forwarded-Host': 'example.com']
+        ['Host': 'example.com:666']                                               | ['X-Forwarded-Host': 'example.com:666']
         ['Host': 'example.com']                                                   | ['X-Forwarded-Port': '80']
         ['Host': 'example.com:666']                                               | ['X-Forwarded-Port': '666']
     }


### PR DESCRIPTION
Fixes #122.

After looking into it a bit better the resources are quite contradicting each other on whether the port should be in the header or not.

Perhaps we could at least make the behaviour configurable to support both flavors?