### PR TITLE
Upgrade to Spring Boot 3.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ subprojects {
     }
 
     ext {
-        springBootVersion = '3.3.2'
+        springBootVersion = '3.4.0'
         resilience4jVersion = '2.2.0'
         okHttpVersion = '4.12.0'
 
@@ -58,15 +58,15 @@ subprojects {
     version = scmVersion.version
 
     dependencies {
-        api group: 'org.springframework', name: 'spring-web', version: '6.1.11'
+        api group: 'org.springframework', name: 'spring-web', version: '6.2.0'
         api group: 'io.github.resilience4j', name: 'resilience4j-circuitbreaker', version: resilience4jVersion
         api group: 'io.github.resilience4j', name: 'resilience4j-ratelimiter', version: resilience4jVersion
         api group: 'io.github.resilience4j', name: 'resilience4j-retry', version: resilience4jVersion
         api group: 'io.github.resilience4j', name: 'resilience4j-micrometer', version: resilience4jVersion
-        api group: 'io.micrometer', name: 'micrometer-core', version: '1.12.3'
-        api group: 'org.apache.commons', name: 'commons-lang3', version: '3.15.0'
+        api group: 'io.micrometer', name: 'micrometer-core', version: '1.14.2'
+        api group: 'org.apache.commons', name: 'commons-lang3', version: '3.17.0'
         api group: 'org.apache.commons', name: 'commons-collections4', version: '4.4'
-        api group: 'commons-io', name: 'commons-io', version: '2.16.1'
+        api group: 'commons-io', name: 'commons-io', version: '2.18.0'
     }
 
     test {

--- a/charon-spring-webflux/src/main/java/com/github/mkopylec/charon/forwarding/interceptors/HttpResponse.java
+++ b/charon-spring-webflux/src/main/java/com/github/mkopylec/charon/forwarding/interceptors/HttpResponse.java
@@ -17,6 +17,7 @@ import reactor.core.publisher.Mono;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Map;
 
 import static com.github.mkopylec.charon.forwarding.RequestForwardingException.requestForwardingError;
 import static com.github.mkopylec.charon.forwarding.Utils.copyHeaders;
@@ -98,6 +99,11 @@ public class HttpResponse implements ClientResponse {
             @Override
             public HttpHeaders getHeaders() {
                 return request.headers();
+            }
+
+            @Override
+            public Map<String, Object> getAttributes() {
+                return request.attributes();
             }
         } : null;
     }

--- a/charon-spring-webmvc/src/main/java/com/github/mkopylec/charon/forwarding/interceptors/HttpRequest.java
+++ b/charon-spring-webmvc/src/main/java/com/github/mkopylec/charon/forwarding/interceptors/HttpRequest.java
@@ -1,9 +1,11 @@
 package com.github.mkopylec.charon.forwarding.interceptors;
 
+import org.jetbrains.annotations.NotNull;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 
 import java.net.URI;
+import java.util.Map;
 
 import static com.github.mkopylec.charon.forwarding.Utils.copyHeaders;
 
@@ -13,12 +15,14 @@ public class HttpRequest implements org.springframework.http.HttpRequest {
     private HttpMethod method;
     private HttpHeaders headers;
     private byte[] body;
+    private final Map<String, Object> attributes;
 
     HttpRequest(org.springframework.http.HttpRequest request, byte[] body) {
         uri = request.getURI();
         method = request.getMethod();
         headers = request.getHeaders();
         this.body = body;
+        attributes = request.getAttributes();
     }
 
     @Override
@@ -57,5 +61,11 @@ public class HttpRequest implements org.springframework.http.HttpRequest {
         HttpHeaders rewrittenHeaders = copyHeaders(headers);
         rewrittenHeaders.setContentLength(body.length);
         setHeaders(rewrittenHeaders);
+    }
+
+    @NotNull
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
     }
 }


### PR DESCRIPTION
This fixes the following error when upgrading a project that uses Charon to Spring Boot 3.4:
```
java.lang.AbstractMethodError: Receiver class com.github.mkopylec.charon.forwarding.interceptors.HttpRequest does not define or inherit an implementation of the resolved method 'abstract java.util.Map getAttributes()' of interface org.springframework.http.HttpRequest.
```